### PR TITLE
Enhancement/pages

### DIFF
--- a/pages/[pageName].tsx
+++ b/pages/[pageName].tsx
@@ -1,15 +1,56 @@
 import { CenterCol, ImgWrapper, PageWrapper } from "../styles/components";
 import { GetServerSideProps, NextPage } from "next";
 import { getDisplayDatetime, getDomainInfo } from "../util";
+import { breakpoints } from "../styles/constants";
 import Image from "next/image";
 import { Page } from "../util/types";
 import { PubDate } from "./blog/post/[postId]";
 import SEO from "../components/seo";
 import { pageMapping } from "../util/db";
+import styled from "styled-components";
 
 interface Props {
   page: Page;
 }
+
+const RightPane = styled.section`
+
+  @media only screen and (min-width: ${breakpoints.sm}px) {
+    display: flex;
+    flex-direction: column;
+    align-items: space-evenly;
+    width: 70%
+  }
+`;
+
+const LeftPane = styled.section`
+  @media only screen and (min-width: ${breakpoints.sm}px) {
+    display: flex;
+    flex-direction: column;
+    align-items: space-evenly;
+    width: 30%;
+  }
+`;
+
+const Header = styled.section`
+
+  @media only screen and (min-width: ${breakpoints.sm}px) {
+    display: flex;
+    flex-direction: column;
+    align-items: space-evenly;
+    position: fixed;
+
+    h1 {
+      display: inline-block;
+      width: 50%;
+      font-size: 2.5rem;
+      line-height: 1.75rem;
+      font-weight: 250;
+      letter-spacing: 3px;
+      font-family: "Outfit", sans-serif;
+    }
+  }
+`;
 
 const SitePage: NextPage<Props> = ({ page }: Props) => {
   if (!page) {
@@ -19,28 +60,31 @@ const SitePage: NextPage<Props> = ({ page }: Props) => {
   return (
     <>
       <SEO pageTitle={page.title} description={page.description} />
-
       <PageWrapper>
         <CenterCol>
-          <h1>{page.title}</h1>
-
-          <PubDate>Published: {getDisplayDatetime(page.updated)}</PubDate>
+        <LeftPane>
+          <Header>
+              <h1>{page.title}</h1>
+              <PubDate>Published: {getDisplayDatetime(page.updated)}</PubDate>
+          </Header>
 
           {page.featuredImage?.url && (
-            <ImgWrapper>
-              <Image
-                src={`https:${page.featuredImage.url}`}
-                alt={page.featuredImage.title}
-                fill={true}
-                style={{
-                  objectFit: "contain"
-                }}
-                sizes="70vw"
-              />
-            </ImgWrapper>
-          )}
-
+              <ImgWrapper>
+                <Image
+                  src={`https:${page.featuredImage.url}`}
+                  alt={page.featuredImage.title}
+                  fill={true}
+                  style={{
+                    objectFit: "contain"
+                  }}
+                  sizes="70vw"
+                />
+              </ImgWrapper>
+            )}
+        </LeftPane>
+        <RightPane>
           <div dangerouslySetInnerHTML={{ __html: page.content! }} />
+        </RightPane>
         </CenterCol>
       </PageWrapper>
     </>

--- a/pages/[pageName].tsx
+++ b/pages/[pageName].tsx
@@ -33,22 +33,21 @@ const LeftPane = styled.section`
 `;
 
 const Header = styled.section`
-
-  @media only screen and (min-width: ${breakpoints.sm}px) {
-    display: flex;
+display: flex;
     flex-direction: column;
     align-items: space-evenly;
-    position: fixed;
+h1 {
+  display: inline-block;
+  width: 50%;
+  font-size: 2.5rem;
+  line-height: 1.75rem;
+  font-weight: 250;
+  letter-spacing: 3px;
+  font-family: "Outfit", sans-serif;
+}
 
-    h1 {
-      display: inline-block;
-      width: 50%;
-      font-size: 2.5rem;
-      line-height: 1.75rem;
-      font-weight: 250;
-      letter-spacing: 3px;
-      font-family: "Outfit", sans-serif;
-    }
+  @media only screen and (min-width: ${breakpoints.sm}px) {
+    position: fixed;
   }
 `;
 
@@ -65,7 +64,11 @@ const SitePage: NextPage<Props> = ({ page }: Props) => {
         <LeftPane>
           <Header>
               <h1>{page.title}</h1>
-              <PubDate>Published: {getDisplayDatetime(page.updated)}</PubDate>
+              <PubDate>
+                Published: 
+                <br></br> 
+                {getDisplayDatetime(page.updated)}
+              </PubDate>
           </Header>
 
           {page.featuredImage?.url && (

--- a/pages/[pageName].tsx
+++ b/pages/[pageName].tsx
@@ -14,7 +14,6 @@ interface Props {
 }
 
 const RightPane = styled.section`
-
   @media only screen and (min-width: ${breakpoints.sm}px) {
     display: flex;
     flex-direction: column;
@@ -33,18 +32,19 @@ const LeftPane = styled.section`
 `;
 
 const Header = styled.section`
-display: flex;
-    flex-direction: column;
-    align-items: space-evenly;
-h1 {
-  display: inline-block;
-  width: 50%;
-  font-size: 2.5rem;
-  line-height: 1.75rem;
-  font-weight: 250;
-  letter-spacing: 3px;
-  font-family: "Outfit", sans-serif;
-}
+  display: flex;
+  flex-direction: column;
+  align-items: space-evenly;
+
+  h1 {
+    display: inline-block;
+    width: 50%;
+    font-size: 2.5rem;
+    line-height: 1.75rem;
+    font-weight: 200;
+    letter-spacing: 3px;
+    font-family: "Outfit", sans-serif;
+  }
 
   @media only screen and (min-width: ${breakpoints.sm}px) {
     position: fixed;
@@ -66,7 +66,7 @@ const SitePage: NextPage<Props> = ({ page }: Props) => {
               <h1>{page.title}</h1>
               <PubDate>
                 Published: 
-                <br></br> 
+                <br /> 
                 {getDisplayDatetime(page.updated)}
               </PubDate>
           </Header>

--- a/pages/blog/[blogPage].tsx
+++ b/pages/blog/[blogPage].tsx
@@ -14,7 +14,7 @@ const PostsWrapper = styled.div`
   flex-direction: column;
   gap: 3rem;
   font-weight: 300;
-  width: 100%;
+  width: 70%;
 `;
 
 const PostWrapper = styled.div`
@@ -111,9 +111,8 @@ const Blog: NextPage<Props> = ({ posts, pages }: Props) => {
   return (
     <PageWrapper>
       <CenterCol>
-        <h1>Blog</h1>
-
         <PostsWrapper>
+          <h1>Blog</h1>
           {!!posts.length &&
             posts.map((post) => (
               <PostWrapper key={post.title}>
@@ -150,22 +149,22 @@ const Blog: NextPage<Props> = ({ posts, pages }: Props) => {
                 <Hr />
               </PostWrapper>
             ))}
+
+          <BlogPageLinks>
+            {pages &&
+              Array(pages)
+                .fill(undefined)
+                .map((_, idx) => {
+                  const page = idx + 1;
+
+                  return (
+                    <Link href={`/blog/${page}`} key={idx}>
+                      {page}
+                    </Link>
+                  );
+                })}
+          </BlogPageLinks>
         </PostsWrapper>
-
-        <BlogPageLinks>
-          {pages &&
-            Array(pages)
-              .fill(undefined)
-              .map((_, idx) => {
-                const page = idx + 1;
-
-                return (
-                  <Link href={`/blog/${page}`} key={idx}>
-                    {page}
-                  </Link>
-                );
-              })}
-        </BlogPageLinks>
       </CenterCol>
     </PageWrapper>
   );

--- a/pages/blog/post/[postId].tsx
+++ b/pages/blog/post/[postId].tsx
@@ -9,6 +9,8 @@ import styled from "styled-components";
 
 export const PubDate = styled.span`
   font-style: italic;
+  font-size: 1rem;
+  line-height: 1rem;
 `;
 
 interface Props {

--- a/styles/components.tsx
+++ b/styles/components.tsx
@@ -3,20 +3,21 @@ import styled from "styled-components";
 
 export const PageWrapper = styled.div`
   display: flex;
-  justify-content: center;
 `;
 
 export const CenterCol = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 1.5rem;
-  width: 100%;
-  margin: 0 0.5rem;
+  margin: 3rem;
 
   h1 {
     font-size: 2.5rem;
-    font-weight: 400;
+    font-weight: 250;
     letter-spacing: 1px;
+    line-height: 1.75rem;
+    font-family: "Outfit", sans-serif;
   }
 
   h2 {
@@ -35,10 +36,11 @@ export const CenterCol = styled.div`
 
   @media only screen and (min-width: ${breakpoints.sm}px) {
     width: ${breakpoints.sm}px;
-
-    h1 {
-      font-size: 3.5rem;
-    }
+    display: flex;
+    flex: 1;
+    flex-direction: row;
+    gap: 1.5rem;
+    margin: 3rem;
   }
 `;
 

--- a/styles/components.tsx
+++ b/styles/components.tsx
@@ -14,7 +14,7 @@ export const CenterCol = styled.div`
 
   h1 {
     font-size: 2.5rem;
-    font-weight: 250;
+    font-weight: 200;
     letter-spacing: 1px;
     line-height: 1.75rem;
     font-family: "Outfit", sans-serif;


### PR DESCRIPTION
Creates double-pane view for pages seperating header and published date to another section 

<img width="1386" alt="Screen Shot 2022-11-12 at 21 00 13" src="https://user-images.githubusercontent.com/19210867/201488242-922decda-c81b-4da7-8037-65e8545b79ac.png">

